### PR TITLE
Added missing cache.requestParameters=src_terms*

### DIFF
--- a/src/main/resources/jnt_customSearchForm/html/customSearchForm.properties
+++ b/src/main/resources/jnt_customSearchForm/html/customSearchForm.properties
@@ -1,1 +1,2 @@
 #cache.expiration=0
+cache.requestParameters=src_terms*


### PR DESCRIPTION
## Description
Added missing cache.requestParameters=src_terms* to allow a correct update of the keywords in the search field when redirected to the search result page.
See this file where the problem is already corrected:
https://github.com/Jahia/search/blob/master/src/main/resources/jnt_simpleSearchForm/html/simpleSearchForm.properties 
Regards,
