### PR TITLE
Proposal to retrieve count in Piwik/Matomo analytics

### DIFF
--- a/src/main/resources/resources/JahiaSearch_en.properties
+++ b/src/main/resources/resources/JahiaSearch_en.properties
@@ -52,8 +52,8 @@ search.results.didYouMean = Did you mean
 search.results.didYouMean.resultsFor = Results for
 search.results.didYouMean.topResults = Top {0} results shown
 # Search results
-search.results.found = Search results for {0}: {1} found
-search.results.sizeNotExact.found = Search results for {0}: about {1} found
+search.results.found = Search results for {0}: <span class="stats_count">{1}</span> found
+search.results.sizeNotExact.found = Search results for {0}: about <span class="stats_count">{1}</span> found
 search.results.no.results = Your search did not match any document
 search.results.pagination.next = Next
 search.results.pagination.previous = Previous


### PR DESCRIPTION
## Description
We have developed a Piwik/Matomo analytics module, that included numerous advanced functionalities, including internal search tracking one (based on this doc: https://matomo.org/docs/site-search/ )
BUT, to be allowed to retrieve the correct "count" results value, we need to have a HTML/CSS marker to separate the 'count number' part from the rest of the content.
This submission is a proposal  to mark the count result with a surrounding HTML SPAN element for easy retrieval of this value (through a class="stats_count" CSS selector for example).
Important: the same modification (add of SPAN around result number var) should be done in all the other languages files.

REM: another solution could be to split the 'search.results.XXX.found' variables in 2 and add the HTML into the view (but it requires more modifications); it's up to you to decide...

Regards,
